### PR TITLE
Add Protodash AI leadership case study

### DIFF
--- a/_work/protodash.md
+++ b/_work/protodash.md
@@ -1,0 +1,25 @@
+---
+headline: "Protodash: Giving teams leverage with AI"
+site: Stripe
+slug: stripe-protodash
+collection: work
+when: 2026
+date: 01-05-2026
+image: /images/stripe.png
+youtube_id: hQFEAZK__q0
+youtube_title: "The internal AI tool that's transforming how Stripe designs products"
+tag: AI Leadership
+---
+AI leadership isn't just telling a team to start using AI. The interesting work is creating the conditions for people to use it confidently, at the quality bar your company expects, in ways that actually change how they work.
+
+I started building Protodash after seeing designers experiment with off-the-shelf AI prototyping tools in reviews. They were fast, but the results often landed in an uncanny valley: the wrong fonts, strange navigation, and what we started calling “blurple slop.” Stripe already had a high-quality, predictable design system, so it felt obvious that AI should be able to build with those real components instead of imagining its own version of our product.
+
+I built much of Protodash with AI, using my engineering background to set the architecture and steer it toward the quality bar I wanted. The first version combined a React shell, Stripe's Sail design system, an MCP integration, and a fairly opinionated bundle of rules that taught AI how to use the project—and stopped it from hallucinating when it couldn't. My goal was to lower the barrier until a designer only needed to know how to run a single command. From there, I connected it to Stripe's dev box infrastructure so a complete, shareable environment could be ready in about two minutes. Eventually, I built Protodash Studio: a browser-based layer where anyone can create, remix, review, and iterate on a prototype without opening a code editor at all.
+
+The leverage comes from giving that capability to the whole team. Designers can get 80–90% of the way to a realistic experience quickly, then spend their time on the taste and craft that elevates it. PMs became some of the most active users, unblocking themselves to explore ideas, test with users earlier, and communicate more clearly with designers. Anyone can contribute back to Protodash, too; designers now send pull requests that evolve the tool around the way they want to work.
+
+Because the prototypes run in code, teams can explore realistic data, empty states, internationalization, different business models, and complete multi-step flows without constructing every state by hand. Reviews happen inside the clickable prototype, where feedback can be summarized and sent back to the AI as the next round of work. On one Radar project, a high-fidelity Protodash prototype became the source of truth for engineering—the first time I had seen that happen in my career as a design manager.
+
+Protodash became a practical way to move our culture toward “demos, not memos.” More importantly, it showed what becomes possible when design leaders can build precise, opinionated tools for their teams: you don't have to wait for an off-the-shelf product or a fully staffed internal-tools team to change how the work gets done.
+
+I joined Claire Vo on [*How I AI*](https://www.lennysnewsletter.com/p/this-week-on-how-i-ai-the-internal) to walk through how Protodash evolved, build a prototype live, and talk about what changes when a company can make tools that fit the way its teams actually work.

--- a/work.html
+++ b/work.html
@@ -53,7 +53,7 @@ seo:
     <div class="space-y-16 relative z-20">
         {% for item in items reversed %}
         <div class="glass rounded-2xl p-8" id="{{ item.slug }}">
-            <div class="lg:grid lg:grid-cols-2 lg:gap-8 items-center">
+            <div class="lg:grid lg:grid-cols-2 lg:gap-8 {% if item.youtube_id %}items-start{% else %}items-center{% endif %}">
                 <div>
                     <div class="mb-6">
                         {% if item.tag %}
@@ -71,9 +71,21 @@ seo:
                     </a>
                     {% endif %}
                 </div>
-                <div class="mt-8 lg:mt-0">
-                    <div class="aspect-[1.8] w-full overflow-hidden rounded-xl">
+                <div class="mt-8 lg:mt-0 {% if item.youtube_id %}lg:sticky lg:top-24{% endif %}">
+                    <div class="aspect-video w-full overflow-hidden rounded-xl bg-slate-950">
+                        {% if item.youtube_id %}
+                        <iframe
+                            class="w-full h-full"
+                            src="https://www.youtube-nocookie.com/embed/{{ item.youtube_id }}"
+                            title="{{ item.youtube_title | default: item.headline | escape }}"
+                            loading="lazy"
+                            referrerpolicy="strict-origin-when-cross-origin"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            allowfullscreen>
+                        </iframe>
+                        {% else %}
                         <img class="w-full h-full object-cover" src="{{ item.image }}" alt="{{ item.headline }}" loading="lazy">
+                        {% endif %}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- add a leadership-focused Protodash case study to the work collection
- embed the *How I AI* interview through reusable `youtube_id` frontmatter
- keep the interview visible beside the longer case study on desktop

## Why

Show how Protodash demonstrates hands-on AI leadership: identifying a systems-level opportunity, building an opinionated internal tool, and distributing leverage across designers and PMs.

## Impact

The new entry appears on the work page and frames Protodash around team enablement, improved design reviews, richer code-based prototypes, and a more direct engineering handoff.

## Validation

- `npm run build`
- `bundle exec jekyll build`
- confirmed the generated work page contains the case study and privacy-enhanced YouTube embed
