### PR TITLE
Add ProtoDash report validation and career context

### DIFF
--- a/_case_studies/protodash.md
+++ b/_case_studies/protodash.md
@@ -8,7 +8,7 @@ slug: stripe-protodash
 standalone: true
 when: 2026
 date: 2026-05-01
-last_modified_at: 2026-07-31
+last_modified_at: 2026-08-22
 image: /images/protodash.jpg
 image_name: protodash
 image_width: 1280
@@ -41,6 +41,15 @@ Because the prototypes run in code, teams can explore realistic data, empty stat
 ## Moving the culture toward demos, not memos
 
 Protodash became a practical way to move our culture toward “demos, not memos.” More importantly, it showed what becomes possible when design leaders can build precise, opinionated tools for their teams: you don't have to wait for an off-the-shelf product or a fully staffed internal-tools team to change how the work gets done.
+
+The organizational impact was later highlighted in Designer Fund and Foundation Capital's [*AI in Design Report 2026*](https://stateofaidesign.com/chapters/tools), which featured Protodash as an example of enterprise design teams building shared AI infrastructure:
+
+<figure class="not-prose my-8 rounded-xl border border-sky-400/20 bg-sky-400/5 p-5 sm:p-6">
+  <blockquote class="text-lg leading-relaxed text-slate-100">
+    “Our team built ProtoDash, an AI-powered product playground with Stripe’s design system baked in. Now anyone can build a realistic prototype in minutes.”
+  </blockquote>
+  <figcaption class="mt-4 text-sm text-slate-300">— Katie Dill, Head of Design at Stripe</figcaption>
+</figure>
 
 That experience sharpened three principles I now bring to AI work: start with a real point of friction rather than a mandate to use the technology; connect AI to the actual systems and standards that define quality; and use the time it saves to increase exploration and critique, not lower the craft bar. AI can maintain momentum, but taste, accountability, and deciding which problem matters still belong to people.
 

--- a/about.html
+++ b/about.html
@@ -2,7 +2,7 @@
 layout: default
 title: About Owen Williams — AI and Product Design Leader
 header: About Owen Williams
-description: Owen Williams is an AI and product design leader, developer, and maker based in Victoria, British Columbia. He leads design for developer experience, documentation, and AI at Stripe.
+description: Now a design leader at Stripe, Owen Williams previously worked as a software engineer, technology journalist, and content designer—a path that shapes how he builds teams and tackles complex technical products.
 permalink: /about/
 image: "/images/card.png"
 color_scheme: purple
@@ -18,6 +18,7 @@ author:
   job_title: AI and Product Design Leader
   company: Stripe
   location: Victoria, British Columbia, Canada
+  bio: Design leader at Stripe with a background in software engineering, technology journalism, and content design.
 ---
 {% capture ascii_settings %}
 {

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ author:
   location: Victoria, British Columbia, Canada
   job_title: AI and Product Design Leader
   company: Stripe
-  bio: Product design leader building teams and tools for AI, developer experience, documentation, and deeply technical products.
+  bio: Design leader at Stripe with a background in software engineering, technology journalism, and content design.
 ---
 <main>
   <section id="index-hero" class="min-h-[68vh] md:min-h-[76vh] relative flex items-center overflow-hidden">


### PR DESCRIPTION
## Summary
- add Owen’s software engineering, technology journalism, and content design background to the portfolio About page and Person schema
- link the 2026 AI in Design Report from the ProtoDash case study
- add Katie Dill’s attributed description of ProtoDash as external validation of its organizational impact

## Validation
- `npm run build`
- `bundle exec jekyll build`
- verified About and ProtoDash in the rendered Netlify branch deploy